### PR TITLE
Bump token expiration time to 30 days

### DIFF
--- a/src/acquireTokens.ts
+++ b/src/acquireTokens.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import qs from "querystring";
 import { Token } from "./tokenStore";
 
-const SECONDS = 1000;
+const SECONDS = 2592000; // 30 days
 const TOKEN_URL = "https://app.vssps.visualstudio.com/oauth2/token";
 const ASSERTION_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 


### PR DESCRIPTION
The Windows tokens `vsts-npm-auth` grants are actually for 90 days, but I think running this once a month would not be such a big deal than having to run devops-buddy almost on every pull of a repo where it's dependencies often change. 